### PR TITLE
[FE][feat] 로그인 유무에 따른 유저 이동 경로 설정

### DIFF
--- a/frontend/utils/PrivateRoute.jsx
+++ b/frontend/utils/PrivateRoute.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import userAuthenticate from '@utils/user-authenticate';
 
 /**
  *  PrivateRoute
@@ -8,21 +9,26 @@ import PropTypes from 'prop-types';
  *  그 외에는 Route 컴포넌트와 같습니다.
  */
 const PrivateRoute = ({ component, ...rest }) => {
+  const [isAuthorized, setIsAuthorized] = useState(userAuthenticate.isAuthorized);
+  const [isPending, setIsPending] = useState(userAuthenticate.isPending);
+
+  useEffect(() => {
+    if (isPending) userAuthenticate.checkUserAuth(setIsAuthorized, setIsPending);
+  }, []);
+
+  if (isPending) return <>확인 중</>;
+  if (isAuthorized) return <Route {...rest} render={() => React.createElement(component)} />;
   return (
     <Route
       {...rest}
-      render={({ location }) =>
-        true ? ( // TODO: true/false 자리에 로그인 여부를 판단하는 조건으로 교체
-          React.createElement(component)
-        ) : (
-          <Redirect
-            to={{
-              pathname: '/',
-              state: { from: location },
-            }}
-          />
-        )
-      }
+      render={({ location }) => (
+        <Redirect
+          to={{
+            pathname: '/',
+            state: { from: location },
+          }}
+        />
+      )}
     />
   );
 };

--- a/frontend/utils/user-authenticate.js
+++ b/frontend/utils/user-authenticate.js
@@ -1,0 +1,35 @@
+import isAuth from '@services/auth/is-auth';
+
+class UserAuthenticate {
+  constructor() {
+    this.isPending = true;
+    this.isAuthorized = false;
+  }
+
+  async checkUserAuth(setIsAuthorized, setIsPending) {
+    try {
+      if (!window.localStorage.getItem('userToken')) this.isAuthorized = false;
+      else {
+        const response = await isAuth();
+        if (response.data.isAuthorized) this.isAuthorized = true;
+        else this.isAuthorized = false;
+      }
+    } catch (err) {
+      this.isAuthorized = true;
+    } finally {
+      this.isPending = false;
+      setIsAuthorized(this.isAuthorized);
+      setIsPending(this.isPending);
+    }
+  }
+
+  login() {
+    this.isAuthorized = true;
+  }
+
+  logout() {
+    this.isAuthorized = false;
+  }
+}
+
+export default new UserAuthenticate();


### PR DESCRIPTION
- UserAuthenticate라는 객체가 유저가 로그인했는지 여부를 저장하고 있습니다.
  - isPending: 초기 업데이트 유무
  - isAuthorized: 로그인 유무
- 페이지 접근 시 해당 객체의 isPending(초기화)여부를 확인합니다.
  - 초기화되었을 경우
    - 로그인 된 상태에서 로그인 페이지 접근 시 issues 페이지로 이동
    - 로그인 안된 상태에서 다른 페이지 접근 시 로그인 페이지로 이동
  - 초기화되지 않았을 경우
    - 유저의 로그인 유무를 확인합니다
      - 토큰이 없을 경우 로그인하지 않음
      - 토큰이 있을 경우 서버로 확인 요청
    - 확인 후 위의 '초기화되었을 경우'의 작업을 수행합니다