### PR TITLE
[FE][feat] milestone list page 구현

### DIFF
--- a/frontend/pages/milestones/MilestoneListPage.jsx
+++ b/frontend/pages/milestones/MilestoneListPage.jsx
@@ -1,5 +1,145 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import Mytable from '@components/common/table';
+// 마일스톤 리스트 테이블
+import service from '@services';
+// 마일스톤 데이터
+import styled from 'styled-components';
+// import MainPageLayout from '@layouts/MainPageLayout';
+import { GoMilestone, GoCheck, GoCalendar } from 'react-icons/go';
 
-const MilestoneListPage = () => <div />;
+const MilestoneListPage = () => {
+  const [open, setOpenMilestone] = useState([]);
+  const [close, setClosedMilestone] = useState([]);
+  const [data, setData] = useState([]);
+  const clickEditBtn = async () => {
+    // 수정버튼
+  };
+  const clickCloseBtn = async () => {
+    // close버튼
+  };
+  const clickDeleteBtn = async () => {
+    // dekete 버튼
+  };
+  const getOpen = async () => {
+    const milestones = await service.getOpenMilestones();
+    setOpenMilestone(milestones.data);
+  };
+  const getClosed = async () => {
+    const milestones = await service.getClosedMilestones();
+    setClosedMilestone(milestones.data);
+  };
+  const getData = async (status) => {
+    const milestones =
+      status === 'close' ? await service.getClosedMilestones() : await service.getOpenMilestones();
+    setData(milestones.data);
+  };
+  useEffect(() => {
+    getOpen();
+    getClosed();
+    getData();
+  }, []);
+  return (
+    <>
+      <Mytable
+        width='100%'
+        header={() => {
+          return (
+            <LabelListHeader>
+              <td colSpan='2'>
+                <HeaderText>
+                  <OpenBtn onClick={() => getData('open')}>
+                    <GoMilestone />
+                    {open.length} Open
+                  </OpenBtn>
+                  <CloseBtn onClick={() => getData('close')}>
+                    <GoCheck />
+                    {close.length} Closed
+                  </CloseBtn>
+                </HeaderText>
+              </td>
+            </LabelListHeader>
+          );
+        }}
+        body={() => {
+          return data.map((milestone) => {
+            return (
+              <TR key={milestone.id}>
+                <TD align='left' padding='10px'>
+                  <Title>{milestone.title}</Title>
+                  <GoCalendar /> Due by {milestone.dueDate.substring(5, 7)},
+                  {milestone.dueDate.substring(8, 10)},{milestone.dueDate.substring(0, 4)}
+                  <br />
+                  {milestone.description}
+                </TD>
+                <TD>
+                  <div>그래프</div>
+                  <br />
+                  <div>그래프설명</div>
+                  <br />
+                  <BTN onClick={() => clickEditBtn()}>edit</BTN>
+                  <BTN onClick={() => clickCloseBtn()}>close</BTN>
+                  <DeleteBTN onClick={() => clickDeleteBtn()}>delete</DeleteBTN>
+                </TD>
+              </TR>
+            );
+          });
+        }}
+      />
+    </>
+  );
+};
 
+const LabelListHeader = styled.tr`
+  background-color: #eee;
+  /* display: flex; */
+  /* justify-content: center; */
+  height: 60px;
+  padding-left: 18px;
+  /* align-items: center; */
+`;
+
+const TR = styled.tr`
+  border-bottom: 1px solid #eee;
+`;
+const OpenBtn = styled.button`
+  color: black;
+  &:visited {
+    color: red;
+  }
+`;
+const CloseBtn = styled(OpenBtn)`
+  color: black;
+`;
+const TD = styled.td`
+  width: ${(props) => props.width || ''};
+  text-align: ${(props) => props.align || 'center'};
+  padding: ${(props) => props.padding || '5px'};
+`;
+const Title = styled.h1`
+  font-size: 1.5em;
+  color: black;
+`;
+const HeaderText = styled.p`
+  color: gray;
+  padding-left: 20px;
+  font-size: 14px;
+`;
+
+const BTN = styled.button`
+  width: ${(props) => props.width || ''};
+  text-align: ${(props) => props.align || 'center'};
+  padding: ${(props) => props.padding || '5px'};
+  border: none;
+  cursor: pointer;
+  background: none;
+  color: blue;
+  padding: 1px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 16px;
+`;
+const DeleteBTN = styled(BTN)`
+  color: red;
+`;
 export default MilestoneListPage;

--- a/frontend/pages/milestones/MilestoneListPage.jsx
+++ b/frontend/pages/milestones/MilestoneListPage.jsx
@@ -1,40 +1,40 @@
 import React, { useEffect, useState } from 'react';
 import Mytable from '@components/common/table';
-// 마일스톤 리스트 테이블
 import service from '@services';
-// 마일스톤 데이터
 import styled from 'styled-components';
-// import MainPageLayout from '@layouts/MainPageLayout';
 import { GoMilestone, GoCheck, GoCalendar } from 'react-icons/go';
 
 const MilestoneListPage = () => {
   const [open, setOpenMilestone] = useState([]);
   const [close, setClosedMilestone] = useState([]);
   const [milestoneList, setMilestoneList] = useState([]);
-  const yes = 1;
-  const no = 0;
-  const clickEditBtn = async () => {
-    // 수정버튼
+  const TRUE = 1;
+  const FALSE = 0;
+  const clickEditBtn = async (id) => {
+    // TODO:수정
+    console.log(id);
   };
-  const clickCloseBtn = async () => {
-    // close버튼
+  const clickCloseBtn = async (id) => {
+    // TODO: close
+    console.log(id);
   };
-  const clickDeleteBtn = async () => {
-    // dekete 버튼
+  const clickDeleteBtn = async (id) => {
+    // TODO:삭제
+    console.log(id);
   };
   const getOpen = async () => {
-    const milestones = await service.getMilestones({ isClosed: no });
+    const milestones = await service.getMilestones({ isClosed: FALSE });
     setOpenMilestone(milestones.data);
   };
   const getClosed = async () => {
-    const milestones = await service.getMilestones({ isClosed: yes });
+    const milestones = await service.getMilestones({ isClosed: TRUE });
     setClosedMilestone(milestones.data);
   };
   const getMilestones = async (status) => {
     const milestones =
       status === 'close'
-        ? await service.getMilestones({ isClosed: yes })
-        : await service.getMilestones({ isClosed: no });
+        ? await service.getMilestones({ isClosed: TRUE })
+        : await service.getMilestones({ isClosed: FALSE });
     setMilestoneList(milestones.data);
   };
   useEffect(() => {
@@ -83,9 +83,9 @@ const MilestoneListPage = () => {
                   <br />
                   <div>그래프설명</div>
                   <br />
-                  <BTN onClick={() => clickEditBtn()}>edit</BTN>
-                  <BTN onClick={() => clickCloseBtn()}>close</BTN>
-                  <DeleteBTN onClick={() => clickDeleteBtn()}>delete</DeleteBTN>
+                  <BTN onClick={() => clickEditBtn(id)}>edit</BTN>
+                  <BTN onClick={() => clickCloseBtn(id)}>close</BTN>
+                  <DeleteBTN onClick={() => clickDeleteBtn(id)}>delete</DeleteBTN>
                 </TD>
               </TR>
             );
@@ -101,7 +101,6 @@ const MilestoneListHeader = styled.tr`
   height: 60px;
   padding-left: 18px;
 `;
-
 const TR = styled.tr`
   border-bottom: 1px solid #eee;
 `;
@@ -125,7 +124,6 @@ const HeaderText = styled.p`
   font-size: ${(props) => props.theme.fontSize.md};
   padding-left: 20px;
 `;
-
 const BTN = styled.button`
   width: ${(props) => props.width || ''};
   text-align: ${(props) => props.align || 'center'};

--- a/frontend/pages/milestones/MilestoneListPage.jsx
+++ b/frontend/pages/milestones/MilestoneListPage.jsx
@@ -10,7 +10,9 @@ import { GoMilestone, GoCheck, GoCalendar } from 'react-icons/go';
 const MilestoneListPage = () => {
   const [open, setOpenMilestone] = useState([]);
   const [close, setClosedMilestone] = useState([]);
-  const [data, setData] = useState([]);
+  const [milestoneList, setMilestoneList] = useState([]);
+  const yes = 1;
+  const no = 0;
   const clickEditBtn = async () => {
     // 수정버튼
   };
@@ -21,22 +23,24 @@ const MilestoneListPage = () => {
     // dekete 버튼
   };
   const getOpen = async () => {
-    const milestones = await service.getOpenMilestones();
+    const milestones = await service.getMilestones({ isClosed: no });
     setOpenMilestone(milestones.data);
   };
   const getClosed = async () => {
-    const milestones = await service.getClosedMilestones();
+    const milestones = await service.getMilestones({ isClosed: yes });
     setClosedMilestone(milestones.data);
   };
-  const getData = async (status) => {
+  const getMilestones = async (status) => {
     const milestones =
-      status === 'close' ? await service.getClosedMilestones() : await service.getOpenMilestones();
-    setData(milestones.data);
+      status === 'close'
+        ? await service.getMilestones({ isClosed: yes })
+        : await service.getMilestones({ isClosed: no });
+    setMilestoneList(milestones.data);
   };
   useEffect(() => {
     getOpen();
     getClosed();
-    getData();
+    getMilestones('open');
   }, []);
   return (
     <>
@@ -44,32 +48,35 @@ const MilestoneListPage = () => {
         width='100%'
         header={() => {
           return (
-            <LabelListHeader>
+            <MilestoneListHeader>
               <td colSpan='2'>
                 <HeaderText>
-                  <OpenBtn onClick={() => getData('open')}>
+                  <OpenBtn onClick={() => getMilestones('open')}>
                     <GoMilestone />
                     {open.length} Open
                   </OpenBtn>
-                  <CloseBtn onClick={() => getData('close')}>
+                  <CloseBtn onClick={() => getMilestones('close')}>
                     <GoCheck />
                     {close.length} Closed
                   </CloseBtn>
                 </HeaderText>
               </td>
-            </LabelListHeader>
+            </MilestoneListHeader>
           );
         }}
         body={() => {
-          return data.map((milestone) => {
+          return milestoneList.map((milestone) => {
+            const { id, title, description, dueDate } = milestone;
+            const year = dueDate.substring(0, 4);
+            const month = dueDate.substring(5, 7);
+            const day = dueDate.substring(8, 10);
             return (
-              <TR key={milestone.id}>
+              <TR key={id}>
                 <TD align='left' padding='10px'>
-                  <Title>{milestone.title}</Title>
-                  <GoCalendar /> Due by {milestone.dueDate.substring(5, 7)},
-                  {milestone.dueDate.substring(8, 10)},{milestone.dueDate.substring(0, 4)}
+                  <Title>{title}</Title>
+                  <GoCalendar /> Due by {month},{day},{year}
                   <br />
-                  {milestone.description}
+                  {description}
                 </TD>
                 <TD>
                   <div>그래프</div>
@@ -89,26 +96,20 @@ const MilestoneListPage = () => {
   );
 };
 
-const LabelListHeader = styled.tr`
+const MilestoneListHeader = styled.tr`
   background-color: #eee;
-  /* display: flex; */
-  /* justify-content: center; */
   height: 60px;
   padding-left: 18px;
-  /* align-items: center; */
 `;
 
 const TR = styled.tr`
   border-bottom: 1px solid #eee;
 `;
 const OpenBtn = styled.button`
-  color: black;
-  &:visited {
-    color: red;
-  }
+  color: ${(props) => props.theme.color.blackColor};
 `;
 const CloseBtn = styled(OpenBtn)`
-  color: black;
+  color: ${(props) => props.theme.color.blackColor};
 `;
 const TD = styled.td`
   width: ${(props) => props.width || ''};
@@ -117,29 +118,25 @@ const TD = styled.td`
 `;
 const Title = styled.h1`
   font-size: 1.5em;
-  color: black;
+  color: ${(props) => props.theme.color.blackColor};
 `;
 const HeaderText = styled.p`
-  color: gray;
+  color: ${(props) => props.theme.color.grayColor};
+  font-size: ${(props) => props.theme.fontSize.md};
   padding-left: 20px;
-  font-size: 14px;
 `;
 
 const BTN = styled.button`
   width: ${(props) => props.width || ''};
   text-align: ${(props) => props.align || 'center'};
   padding: ${(props) => props.padding || '5px'};
-  border: none;
+  color: ${(props) => props.theme.color.blueColor};
+  font-size: ${(props) => props.theme.fontSize.md};
   cursor: pointer;
-  background: none;
-  color: blue;
   padding: 1px;
-  text-align: center;
-  text-decoration: none;
   display: inline-block;
-  font-size: 16px;
 `;
 const DeleteBTN = styled(BTN)`
-  color: red;
+  color: ${(props) => props.theme.color.redColor};
 `;
 export default MilestoneListPage;

--- a/frontend/services/index.js
+++ b/frontend/services/index.js
@@ -1,10 +1,12 @@
 import apiRequest from '@utils/api-request';
 import labelService from './label';
+import MilestoneService from './milestones/index';
 // import auth from './auth';
 
 const Service = () => {
   return {
     ...labelService(apiRequest),
+    ...MilestoneService(apiRequest),
     // ...auth(),
   };
 };

--- a/frontend/services/milestones/getters.js
+++ b/frontend/services/milestones/getters.js
@@ -1,0 +1,21 @@
+const getters = (apiRequest) => {
+  const getClosedMilestones = () => {
+    return apiRequest.get(`/api/milestones`, {
+      params: {
+        isClosed: '1',
+      },
+    });
+  };
+  const getOpenMilestones = () => {
+    return apiRequest.get(`/api/milestones`, {
+      params: {
+        isClosed: '0',
+      },
+    });
+  };
+  return {
+    getOpenMilestones,
+    getClosedMilestones,
+  };
+};
+export default getters;

--- a/frontend/services/milestones/getters.js
+++ b/frontend/services/milestones/getters.js
@@ -1,21 +1,13 @@
 const getters = (apiRequest) => {
-  const getClosedMilestones = () => {
+  const getMilestones = ({ isClosed = '0' }) => {
     return apiRequest.get(`/api/milestones`, {
       params: {
-        isClosed: '1',
-      },
-    });
-  };
-  const getOpenMilestones = () => {
-    return apiRequest.get(`/api/milestones`, {
-      params: {
-        isClosed: '0',
+        isClosed,
       },
     });
   };
   return {
-    getOpenMilestones,
-    getClosedMilestones,
+    getMilestones,
   };
 };
 export default getters;

--- a/frontend/services/milestones/index.js
+++ b/frontend/services/milestones/index.js
@@ -1,0 +1,15 @@
+// import adders from './adders';
+import getters from './getters';
+// import updaters from './updaters'
+// import deleters from './deleters'
+
+const MilestoneService = (apiRequest) => {
+  return {
+    // ...adders(),
+    ...getters(apiRequest),
+    // ...updaters(axios),
+    // ...deleters(axios),
+  };
+};
+
+export default MilestoneService;


### PR DESCRIPTION
## `MilestoneListPage.jsx`
- open 상태인 마일스톤과 close 상태의 마일스톤을 가져와서 Mytable의 header에서 몇개의 마일스톤이 closed되고 open되어 있는지 표시
- Mytable의 header 부분의 open 버튼을 누르면 open 상태의 마일스톤, closed 버튼을 누르면 closed 상태의 마일스톤을 보여준다. 아무 버튼도 안누른 상태일때도 open 상태의 마일스톤을 보여준다.  
![image](https://user-images.githubusercontent.com/57527380/98144299-93d24900-1f0d-11eb-9541-2bc447defea5.png)
## 수정 필요한 부분
- 테이블의 한 칸을 component로 분리
- issue와 관련되어있는 부분 구현(그래프,그래프 상세)