### PR TITLE
[Common][feat] 이슈 리스트 페이지 작성

### DIFF
--- a/backend/services/issue/getIssues.js
+++ b/backend/services/issue/getIssues.js
@@ -28,7 +28,7 @@ const getIssues = async (req, res) => {
       },
     });
 
-    return res.json({ issues });
+    return res.json(issues);
   } catch (e) {
     return res.sendStatus(500);
   }

--- a/backend/services/issue/getIssues.js
+++ b/backend/services/issue/getIssues.js
@@ -41,6 +41,7 @@ const getIssues = async (req, res) => {
           },
         },
       ],
+      order: [['created_at', 'DESC']],
     });
 
     return res.json(issues);

--- a/backend/services/issue/getIssues.js
+++ b/backend/services/issue/getIssues.js
@@ -1,4 +1,4 @@
-const { issue } = require('../../sequelize/models');
+const { issue, milestone, issue_label, label } = require('../../sequelize/models');
 
 /**
  * @todo 필터 검색 로직 구현
@@ -26,6 +26,21 @@ const getIssues = async (req, res) => {
       where: {
         isClosed: parsedClosed,
       },
+      include: [
+        {
+          model: milestone,
+          attributes: ['title'],
+        },
+        {
+          model: issue_label,
+          attributes: ['id'],
+          raw: true,
+          include: {
+            model: label,
+            attributes: ['title', 'color'],
+          },
+        },
+      ],
     });
 
     return res.json(issues);

--- a/backend/services/issue/getIssues.js
+++ b/backend/services/issue/getIssues.js
@@ -1,4 +1,4 @@
-const { issue, milestone, issue_label, label } = require('../../sequelize/models');
+const { issue, milestone, user_issue, user, issue_label, label } = require('../../sequelize/models');
 
 /**
  * @todo 필터 검색 로직 구현
@@ -30,6 +30,14 @@ const getIssues = async (req, res) => {
         {
           model: milestone,
           attributes: ['title'],
+        },
+        {
+          model: user_issue,
+          attributes: ['id'],
+          include: {
+            model: user,
+            attributes: ['nickName'],
+          },
         },
         {
           model: issue_label,

--- a/frontend/components/Header.jsx
+++ b/frontend/components/Header.jsx
@@ -27,6 +27,7 @@ const Header = () => {
 const Component = styled.header`
   width: 100%;
   height: 72px;
+  min-height: 72px;
   position: relative;
   display: flex;
   align-items: center;

--- a/frontend/components/IssueCard.jsx
+++ b/frontend/components/IssueCard.jsx
@@ -102,7 +102,7 @@ IssueCard.propTypes = {
   title: PropTypes.string.isRequired,
   labelList: PropTypes.array,
   issueId: PropTypes.number.isRequired,
-  created: PropTypes.object.isRequired,
+  created: PropTypes.string.isRequired,
   userNickname: PropTypes.string.isRequired,
   milestoneName: PropTypes.string,
   isClosed: PropTypes.bool.isRequired,

--- a/frontend/components/IssueCard.jsx
+++ b/frontend/components/IssueCard.jsx
@@ -35,7 +35,7 @@ const IssueCard = ({ title, labelList, issueId, created, userNickname, milestone
   );
 };
 
-const Wrapper = styled.article`
+const Wrapper = styled.tr`
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -46,7 +46,7 @@ const Wrapper = styled.article`
   }
 `;
 
-const CardMain = styled.div`
+const CardMain = styled.td`
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -75,7 +75,7 @@ const Title = styled.h2`
   }
 `;
 
-const CardInfo = styled.div`
+const CardInfo = styled.td`
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/frontend/components/issue/IssueList.jsx
+++ b/frontend/components/issue/IssueList.jsx
@@ -4,6 +4,13 @@ import Mytable from '@components/common/table';
 import IssueCard from '@components/IssueCard';
 import Label from '@components/common/label';
 
+const labelGenerator = (issueLabels) => {
+  return issueLabels.reduce((acc, issueLabel) => {
+    acc.push(<Label text={issueLabel.label.title} bg={issueLabel.label.color} key={issueLabel.id} />);
+    return acc;
+  }, []);
+};
+
 const IssueList = ({ issues }) => {
   return (
     <>
@@ -15,16 +22,7 @@ const IssueList = ({ issues }) => {
             return (
               <IssueCard
                 title={issue.title}
-                labelList={issue.issue_labels.reduce((acc, issueLabels) => {
-                  acc.push(
-                    <Label
-                      text={issueLabels.label.title}
-                      bg={issueLabels.label.color}
-                      key={issueLabels.id}
-                    />,
-                  );
-                  return acc;
-                }, [])}
+                labelList={labelGenerator(issue.issue_labels)}
                 issueId={issue.id}
                 created={issue.createdAt}
                 userNickname=''

--- a/frontend/components/issue/IssueList.jsx
+++ b/frontend/components/issue/IssueList.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Mytable from '@components/common/table';
 import IssueCard from '@components/IssueCard';
 import Label from '@components/common/label';
+import IssueListHeader from './IssueListHeader';
 
 const labelGenerator = (issueLabels) => {
   return issueLabels.reduce((acc, issueLabel) => {
@@ -16,7 +17,9 @@ const IssueList = ({ issues }) => {
     <>
       <Mytable
         width='100%'
-        renderHeader={() => {}}
+        renderHeader={() => {
+          return <IssueListHeader />;
+        }}
         renderBody={() => {
           return issues.map((issue) => {
             return (

--- a/frontend/components/issue/IssueList.jsx
+++ b/frontend/components/issue/IssueList.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import IssueCard from '@components/IssueCard';
+import Label from '@components/common/label';
 
 const IssueList = ({ issues }) => {
   return (
@@ -9,9 +10,16 @@ const IssueList = ({ issues }) => {
         return (
           <IssueCard
             title={issue.title}
+            labelList={issue.issue_labels.reduce((acc, issueLabels) => {
+              acc.push(
+                <Label text={issueLabels.label.title} bg={issueLabels.label.color} key={issueLabels.id} />,
+              );
+              return acc;
+            }, [])}
             issueId={issue.id}
             created={issue.createdAt}
             userNickname=''
+            milestoneName={issue.milestone.title}
             isClosed={issue.isClosed}
             key={issue.id}
           />

--- a/frontend/components/issue/IssueList.jsx
+++ b/frontend/components/issue/IssueList.jsx
@@ -1,30 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Mytable from '@components/common/table';
 import IssueCard from '@components/IssueCard';
 import Label from '@components/common/label';
 
 const IssueList = ({ issues }) => {
   return (
     <>
-      {issues.map((issue) => {
-        return (
-          <IssueCard
-            title={issue.title}
-            labelList={issue.issue_labels.reduce((acc, issueLabels) => {
-              acc.push(
-                <Label text={issueLabels.label.title} bg={issueLabels.label.color} key={issueLabels.id} />,
-              );
-              return acc;
-            }, [])}
-            issueId={issue.id}
-            created={issue.createdAt}
-            userNickname=''
-            milestoneName={issue.milestone.title}
-            isClosed={issue.isClosed}
-            key={issue.id}
-          />
-        );
-      })}
+      <Mytable
+        width='100%'
+        renderHeader={() => {}}
+        renderBody={() => {
+          return issues.map((issue) => {
+            return (
+              <IssueCard
+                title={issue.title}
+                labelList={issue.issue_labels.reduce((acc, issueLabels) => {
+                  acc.push(
+                    <Label
+                      text={issueLabels.label.title}
+                      bg={issueLabels.label.color}
+                      key={issueLabels.id}
+                    />,
+                  );
+                  return acc;
+                }, [])}
+                issueId={issue.id}
+                created={issue.createdAt}
+                userNickname=''
+                milestoneName={issue.milestone.title}
+                isClosed={issue.isClosed}
+                key={issue.id}
+              />
+            );
+          });
+        }}
+      />
     </>
   );
 };

--- a/frontend/components/issue/IssueList.jsx
+++ b/frontend/components/issue/IssueList.jsx
@@ -28,7 +28,7 @@ const IssueList = ({ issues }) => {
                 labelList={labelGenerator(issue.issue_labels)}
                 issueId={issue.id}
                 created={issue.createdAt}
-                userNickname=''
+                userNickname={issue.user_issues[0].user.nickName}
                 milestoneName={issue.milestone.title}
                 isClosed={issue.isClosed}
                 key={issue.id}

--- a/frontend/components/issue/IssueList.jsx
+++ b/frontend/components/issue/IssueList.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import IssueCard from '@components/IssueCard';
+
+const IssueList = ({ issues }) => {
+  return (
+    <>
+      {issues.map((issue) => {
+        return (
+          <IssueCard
+            title={issue.title}
+            issueId={issue.id}
+            created={issue.createdAt}
+            userNickname=''
+            isClosed={issue.isClosed}
+            key={issue.id}
+          />
+        );
+      })}
+    </>
+  );
+};
+
+IssueList.propTypes = {
+  issues: PropTypes.array,
+};
+
+IssueList.defaultProps = {
+  issues: [],
+};
+
+export default IssueList;

--- a/frontend/components/issue/IssueListHeader.jsx
+++ b/frontend/components/issue/IssueListHeader.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const IssueListHeader = () => {
+  return <Wrapper />;
+};
+
+const Wrapper = styled.tr``;
+
+export default IssueListHeader;

--- a/frontend/layouts/MainPageLayout.jsx
+++ b/frontend/layouts/MainPageLayout.jsx
@@ -27,7 +27,7 @@ const Container = styled.div`
 const Main = styled.main`
   width: 100%;
   max-width: 1024px;
-  margin-top: 3rem;
+  margin: 3rem 0;
 `;
 
 export default MainPageLayout;

--- a/frontend/pages/issues/IssueListPage.jsx
+++ b/frontend/pages/issues/IssueListPage.jsx
@@ -1,10 +1,24 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import MainPageLayout from '@layouts/MainPageLayout';
+import LabelMilestoneTab from '@components/LabelMilestoneTab';
+import IssueList from '@components/issue/IssueList';
+import service from '@services';
 
-const IssueListPage = () => (
-  <MainPageLayout>
-    <></>
-  </MainPageLayout>
-);
+const IssueListPage = () => {
+  const issuesPerPage = 20;
+  const [issues, setIssues] = useState([]);
+
+  useEffect(async () => {
+    const { data } = await service.initialGetIssues(issuesPerPage);
+    setIssues(data.rows);
+  }, []);
+
+  return (
+    <MainPageLayout>
+      <LabelMilestoneTab />
+      <IssueList issues={issues} />
+    </MainPageLayout>
+  );
+};
 
 export default IssueListPage;

--- a/frontend/services/index.js
+++ b/frontend/services/index.js
@@ -1,12 +1,14 @@
 import apiRequest from '@utils/api-request';
 import labelService from './label';
-import MilestoneService from './milestones/index';
+import milestoneService from './milestones';
+import issueService from './issue';
 // import auth from './auth';
 
 const Service = () => {
   return {
     ...labelService(apiRequest),
-    ...MilestoneService(apiRequest),
+    ...milestoneService(apiRequest),
+    ...issueService(apiRequest),
     // ...auth(),
   };
 };

--- a/frontend/services/issue/getters.js
+++ b/frontend/services/issue/getters.js
@@ -1,0 +1,18 @@
+// const querystring = require('querystring');
+
+const getters = (apiRequest) => {
+  const initialGetIssues = (count) => {
+    const params = {
+      page: 1,
+      count,
+      closed: 'false',
+    };
+    return apiRequest.get(`/api/issues`, { params });
+  };
+
+  return {
+    initialGetIssues,
+  };
+};
+
+export default getters;

--- a/frontend/services/issue/index.js
+++ b/frontend/services/issue/index.js
@@ -1,0 +1,15 @@
+// import adders from './adders';
+// import deleters from './deleters';
+import getters from './getters';
+// import updaters from './updaters'
+
+const issueService = (apiRequest) => {
+  return {
+    // ...adders(),
+    ...getters(apiRequest),
+    // ...updaters(axios),
+    // ...deleters(axios),
+  };
+};
+
+export default issueService;


### PR DESCRIPTION
- Mytable 내부에 issue 목록을 보여줍니다
- 페이지 진입 시 기본 설정(pageCount : 1, isClosed: false)으로 issue를 조회합니다
- DB 조회 시 label 정보 list, milestone 정보, 유저 닉네임을 함께 전달합니다
- issue를 기반으로 IssueCard 컴포넌트를 생성합니다