### PR TITLE
[FE][feat] : 리스트 페이지 라벨 및 마일스톤 개수 표시

### DIFF
--- a/frontend/pages/issues/IssueListPage.jsx
+++ b/frontend/pages/issues/IssueListPage.jsx
@@ -11,16 +11,26 @@ const IssueListPage = () => {
   const issuesPerPage = 20;
   const history = useHistory();
   const [issues, setIssues] = useState([]);
+  const [LabelMilestoneNumer, setLabelMilestoneNumber] = useState({ labels: 0, milestones: 0 });
 
   useEffect(async () => {
-    const { data } = await service.initialGetIssues(issuesPerPage);
-    setIssues(data.rows);
+    const { data: issuesResponse } = await service.initialGetIssues(issuesPerPage);
+    setIssues(issuesResponse.rows);
+    const { data: labelsResponse } = await service.getLabels();
+    const { data: milestonesResponse } = await service.getMilestones({});
+    setLabelMilestoneNumber({
+      labels: labelsResponse.length,
+      milestones: milestonesResponse.length,
+    });
   }, []);
 
   return (
     <MainPageLayout>
       <NavBar>
-        <LabelMilestoneTab />
+        <LabelMilestoneTab
+          labelsNumber={LabelMilestoneNumer.labels}
+          milestonesNumber={LabelMilestoneNumer.milestones}
+        />
         <Button
           text='New issue'
           onClick={() => {

--- a/frontend/pages/issues/IssueListPage.jsx
+++ b/frontend/pages/issues/IssueListPage.jsx
@@ -36,6 +36,7 @@ const IssueListPage = () => {
           onClick={() => {
             history.push('/issues/new');
           }}
+          size='large'
         />
       </NavBar>
       <IssueList issues={issues} />


### PR DESCRIPTION
- IssueListPage에서 라벨 및 마일스톤 조회
  - 해당 개수를 state로 저장하고 LabelMilestoneTab에 전달

![LM 개수](https://user-images.githubusercontent.com/34625313/98618664-02b40580-2345-11eb-8a86-3b0eafa54ede.png)
