### PR TITLE
[FE][fix] : 라벨, 마일스톤 페이지 버그 수정

### DIFF
--- a/frontend/pages/common/LabelMilestonePage.jsx
+++ b/frontend/pages/common/LabelMilestonePage.jsx
@@ -14,7 +14,7 @@ const LabelMilestonePage = ({ location }) => {
     <Layout>
       <LabelMilestonePageNavbar location={location} newButton={newButton} />
       <Switch>
-        <Route path='/labels' component={LabelListPage} />
+        <Route path='/labels' render={() => <LabelListPage setNewButton={setNewButton} />} />
         <Route
           exact
           path='/milestones'

--- a/frontend/pages/labels/LabelListPage.jsx
+++ b/frontend/pages/labels/LabelListPage.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useContext } from 'react';
-import styled from 'styled-components';
+import React, { useContext, useEffect, useReducer } from 'react';
+import PropTypes from 'prop-types';
 import LabelList from '@components/label/LabelList';
 import LabelForm from '@components/label/LabelForm';
 import { LabelContext } from '@store/LabelProvider';
@@ -7,12 +7,16 @@ import { labelActions } from '@store/actions';
 import service from '@services';
 import Button from '@components/common/Button';
 
-const LabelListPage = () => {
+const isAddingReducer = (state) => {
+  return !state;
+};
+
+const LabelListPage = ({ setNewButton }) => {
   const [labels, dispatch] = useContext(LabelContext);
-  const [isAdding, setIsAdding] = useState(false);
+  const [isAdding, isAddingDispatch] = useReducer(isAddingReducer, false);
 
   const onAddLabel = (label) => {
-    setIsAdding(false);
+    isAddingDispatch();
     service
       .addLabel(label)
       .then(({ data: createdLabel }) =>
@@ -48,15 +52,15 @@ const LabelListPage = () => {
       type: labelActions.END_EDIT_LABEL,
       payload: id,
     });
+
+  useEffect(() => {
+    setNewButton(<Button text='New label' size='large' onClick={isAddingDispatch} />);
+  }, []);
+
   return (
     <>
-      <ButtonRow>
-        <ButtonWrapper>
-          <Button text='New label' size='large' onClick={() => setIsAdding(true)} />
-        </ButtonWrapper>
-      </ButtonRow>
       {isAdding && (
-        <LabelForm onSave={onAddLabel} onCancel={() => setIsAdding(false)} saveButtonText='Create label' />
+        <LabelForm onSave={onAddLabel} onCancel={isAddingDispatch} saveButtonText='Create label' />
       )}
       <LabelList
         labels={labels}
@@ -70,16 +74,8 @@ const LabelListPage = () => {
   );
 };
 
-const ButtonRow = styled.div`
-  position: relative;
-  margin-bottom: 24px;
-`;
-
-const ButtonWrapper = styled.div`
-  width: 100%;
-  text-align: right;
-  position: absolute;
-  top: -32px;
-`;
+LabelListPage.propTypes = {
+  setNewButton: PropTypes.func.isRequired,
+};
 
 export default LabelListPage;


### PR DESCRIPTION
- 라벨, 마일스톤 페이지 간 버튼 생성 방식이 달라 겹쳐보이는 문제 발생
- setNewButton 사용해 해결